### PR TITLE
Pad with zeros when `num_channels` < 4 in `ImageEncoder`

### DIFF
--- a/tests/model/test_embedding.py
+++ b/tests/model/test_embedding.py
@@ -1,6 +1,6 @@
 import torch
 
-from gia.model.embedding import Embeddings, LocalPositionEncodings
+from gia.model.embedding import Embeddings, ImageEncoder, LocalPositionEncodings
 
 
 def test_local_position_encodings():
@@ -29,6 +29,33 @@ def test_local_position_encodings_same():
     assert torch.allclose(pos_emb[1:], pos_emb[-1:]), "Position encodings should not depend on batch index"
     assert torch.allclose(pos_emb[:, 1:], pos_emb[:, -1:]), "Position encodings should not depend on timestep"
     assert torch.allclose(pos_emb[:, :, 1:], pos_emb[:, :, -1:]), "Position encodings should not vary locally"
+
+
+def test_image_encoder():
+    batch_size = 8
+    in_channels = 4
+    num_res_channels = 32
+    out_features = 128
+    num_groups = 4
+    patch_size = 16
+
+    image_encoder = ImageEncoder(in_channels, num_res_channels, out_features, num_groups, patch_size)
+
+    # Test with input images of shape (batch_size, 3, patch_size, patch_size)
+    input_images = torch.randn(batch_size, 3, patch_size, patch_size)
+    encoded_images = image_encoder(input_images)
+    assert encoded_images.shape == (
+        batch_size,
+        out_features,
+    ), f"Expected shape ({batch_size}, {out_features}), got {encoded_images.shape}"
+
+    # Test with input images of shape (batch_size, 4, patch_size, patch_size)
+    input_images = torch.randn(batch_size, 4, patch_size, patch_size)
+    encoded_images = image_encoder(input_images)
+    assert encoded_images.shape == (
+        batch_size,
+        out_features,
+    ), f"Expected shape ({batch_size}, {out_features}), got {encoded_images.shape}"
 
 
 def test_embeddings():


### PR DESCRIPTION
Allow to work with any image with `num_channels` < 4