### PR TITLE
Speedup for sequence of images

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ REQUIRED_PKGS = [
     "hydra-core",
     "accelerate",
     "wandb",
-    "datasets @ git+https://github.com/huggingface/datasets.git@main",
+    "datasets @ git+https://github.com/qgallouedec/datasets.git@speedup-sequence-of-sequece-of-array",
     "opencv-python",
     "Pillow",
 ]


### PR DESCRIPTION
`datasets` is designed to efficiently handle arrays and sequences of arrays. But not sequences of sequences of arrays (our dataset is a list of episodes, and each episode is a list of images, which are arrays). I've added this support in `datasets`. Without it, the use of image datasets takes an eternity, even two. The patch isn't very elegant, but it works fine. I don't plan to submit any PRs to datasets at the moment, so we'll stick with this fork dependency for now.