### PR TITLE
Fix for Windows install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -108,8 +108,8 @@ setup(
     url="https://github.com/huggingface/jat",
     download_url="https://github.com/huggingface/jat/tags",
     license="Apache 2.0",
-    package_dir={"": "./"},
-    packages=find_packages(where="./", include="jat*"),
+    package_dir={"": "."},
+    packages=find_packages(where=".", include="jat*"),
     install_requires=REQUIRED_PKGS,
     extras_require=EXTRAS_REQUIRE,
     classifiers=[


### PR DESCRIPTION
With the changes from the PR, I was able to install this in Windows 10 64 bit and run inference on my CPU.

Prior to the changes, pip install commands would fail at:
```shell
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error    
```

With the error:
```shell
site-packages\setuptools\_distutils\util.py", line 134, in convert_path
          raise ValueError("path '%s' cannot end with '/'" % pathname)
      ValueError: path './' cannot end with '/'
```

According to the error message, I have removed the `/` which fixed the issue for me. 
Please feel free to retest that everything is still fine for Linux when considering the PR.