### PR TITLE
Fix model loading issue and ensure package data inclusion

### DIFF
--- a/scripts/eval_jat.py
+++ b/scripts/eval_jat.py
@@ -178,10 +178,11 @@ def main():
             warnings.warn(f"Task {task} is not supported.")
 
     # Extract mean and std, and save scores dict
-    eval_path = f"{model_args.model_name_or_path}/evaluations.json"
+    output_dir = f"runs/{model_args.model_name_or_path}"
+    eval_path = f"{output_dir}/evaluations.json"
 
-    if not os.path.exists(f"{model_args.model_name_or_path}"):
-        os.makedirs(f"{model_args.model_name_or_path}")
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
 
     if evaluations:
         with open(eval_path, "w") as file:
@@ -189,7 +190,7 @@ def main():
 
     # Save the video
     if eval_args.save_video:
-        replay_path = f"{model_args.model_name_or_path}/replay.mp4"
+        replay_path = f"{output_dir}/replay.mp4"
         save_video_grid(video_list, input_fps, replay_path, output_fps=30, max_length_seconds=180)
     else:
         replay_path = None

--- a/setup.py
+++ b/setup.py
@@ -128,6 +128,9 @@ setup(
     keywords="simulation environments machine learning reinforcement learning deep learning",
     zip_safe=False,  # Required for mypy to find the py.typed file
     python_requires=">=3.8",
+    package_data={
+        "jat": ["eval/rl/scores_dict.json"],
+    },
 )
 
 # When building extension modules `cmake_install_dir` should always be set to the


### PR DESCRIPTION
## Summary  

This pull request addresses two key issues:  
1. **Improper model loading** due to the output directory structure in the evaluation script.  
2. **Missing package data file** required for evaluation.  

## Changes  

### Evaluation Script Updates  
- **[`scripts/eval_jat.py`](diffhunk://#diff-d7732835fb8f60ebb8ff41d54caad0b260255af661b4e2fafd436de92fa35271L181-R193)**  
  - Updated the output directory structure to store evaluation results and replay videos in a separate `runs` directory.  
  - Previously, the code directly used `model_args.model_name_or_path` as the folder name (e.g., `"jat-project/jat"`).  
  - However, after this folder is created, running `scripts/eval_jat.py` causes an issue where  
    `transformers.AutoModelForCausalLM.from_pretrained()` recognizes `"jat-project/jat"` as a **local directory** instead of a remote one, leading to **incorrect model loading**.  

### Package Setup Updates  
- **[`setup.py`](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R131-R133)**  
  - Added `scores_dict.json` to the package data to ensure it is included in the distribution.  
  - When running `eval_jat.py`, the script searches for `scores_dict.json` in the installed package directory.  
  - However, since `setup.py` did not explicitly specify the inclusion of `scores_dict.json`, the script would **fail due to the missing file**.  
  - This update resolves that issue by ensuring the file is included during installation.  